### PR TITLE
Set content type for TextResult.

### DIFF
--- a/src/KaraLib/src/kara/ActionResult.kt
+++ b/src/KaraLib/src/kara/ActionResult.kt
@@ -17,6 +17,7 @@ trait ActionResult {
  */
 open class TextResult(val text: String) : ActionResult {
     override fun writeResponse(context: ActionContext) {
+        context.response.setContentType("text/html")
         val out = context.response.getWriter()
         out?.print(text)
         out?.flush()


### PR DESCRIPTION
Problems with encoding in TextResult without setting http response content type.
