### PR TITLE
Add ControllerInterface annotation.

### DIFF
--- a/src/KaraLib/src/kara/Annotations.kt
+++ b/src/KaraLib/src/kara/Annotations.kt
@@ -31,3 +31,10 @@ Default is / for top level root object or lowercased object name for inner objec
 
 /** Used to annotate route objects, when you want to use nested functions as routes **/
 @Retention(AnnotationRetention.RUNTIME) @Target(AnnotationTarget.CLASS) annotation class Controller(val contentType: String)
+
+/**
+ * Used to annotate route objects, when you want to use implementations of class as routes.
+ * Only final classes will be treated as implementations of interface controller.
+ * You must not have more than one implementation of every annotated interface controller.
+ **/
+@Retention(AnnotationRetention.RUNTIME) @Target(AnnotationTarget.CLASS) annotation class InterfaceController

--- a/src/KaraLib/src/kara/Application.kt
+++ b/src/KaraLib/src/kara/Application.kt
@@ -1,5 +1,6 @@
 package kara
 
+import kara.internal.ResourceDescriptor
 import kara.internal.scanPackageForResources
 import kotlinx.reflection.urlDecode
 import org.slf4j.Logger
@@ -77,7 +78,7 @@ open class Application(val config: ApplicationConfig, val appContext: String = "
         watchKeys.clear()
     }
 
-    fun watchUrls(resourceTypes: List<KAnnotatedElement>) {
+    fun watchUrls(resourceTypes: List<Pair<KAnnotatedElement, ResourceDescriptor>>) {
         val paths = HashSet<Path>()
         val visitor = object : SimpleFileVisitor<Path?>() {
             override fun preVisitDirectory(dir: Path?, attrs: BasicFileAttributes): FileVisitResult {
@@ -91,7 +92,7 @@ open class Application(val config: ApplicationConfig, val appContext: String = "
                 return FileVisitResult.CONTINUE
             }
         }
-        val loaders = resourceTypes.map { it.javaClass.classLoader }.toSet()
+        val loaders = resourceTypes.map { it.first.javaClass.classLoader }.toSet()
         for (loader in loaders) {
             if (loader is URLClassLoader) {
                 val loaderUrls = loader.urLs

--- a/src/KaraLib/src/kara/ApplicationContext.kt
+++ b/src/KaraLib/src/kara/ApplicationContext.kt
@@ -19,7 +19,7 @@ class ApplicationContext(val config: ApplicationConfig,
                          packages: List<String>,
                          val classLoader: ClassLoader,
                          val reflectionCache: MutableMap<Pair<Int, String>, List<Class<*>>>,
-                         val resourceTypes: List<KAnnotatedElement>) {
+                         val resourceTypes: List<Pair<KAnnotatedElement, ResourceDescriptor>>) {
     val logger = LoggerFactory.getLogger(this.javaClass)!!
     private val interceptors = ArrayList<(HttpServletRequest, HttpServletResponse, ResourceDescriptor?, (HttpServletRequest, HttpServletResponse, ResourceDescriptor?) -> Boolean) -> Boolean>()
     private val monitorInstances = ArrayList<ApplicationContextMonitor>()

--- a/src/KaraLib/src/kara/internal/ReflectionUtils.kt
+++ b/src/KaraLib/src/kara/internal/ReflectionUtils.kt
@@ -3,12 +3,11 @@ package kara.internal
 import kara.FunctionWrapperResource
 import kara.Location
 import kara.Resource
-import kotlinx.reflection.annotationClassCached
 import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 
-fun String.appendPathElement(part : String) = buildString {
+fun String.appendPathElement(part: String) = buildString {
     append(this@appendPathElement)
     if (!this.endsWith("/")) {
         append("/")
@@ -18,7 +17,7 @@ fun String.appendPathElement(part : String) = buildString {
         append(part.substring(1))
     } else {
         append(part)
-    }                                                                                                                                               
+    }
 }
 
 fun Class<*>.routePrefix(): String {
@@ -32,9 +31,13 @@ fun Class<*>.routePrefix(): String {
 
 @Suppress("UNCHECKED_CAST")
 fun KAnnotatedElement.route(): ResourceDescriptor {
-    val annotation = annotations.firstOrNull { a -> karaAnnotations.any { a.annotationClassCached == it } }
-                    ?: error("No HTTP method annotation found in ${javaClass.name}")
+    val karaAnnotation = this.getKaraAnnotation() ?: (this as? KClass<*>)?.getKaraAnnotationFromSuper()
+            ?: error("No HTTP method annotation found in ${javaClass.name}")
+    return route(karaAnnotation)
+}
 
+@Suppress("UNCHECKED_CAST")
+fun KAnnotatedElement.route(annotation: Annotation): ResourceDescriptor {
     return when {
         this is KClass<*> && Resource::class.java.isAssignableFrom(this.java) ->
             ResourceDescriptor.fromResourceClass(this as KClass<out Resource>, annotation)

--- a/src/KaraLib/src/kara/internal/ResourceDispatcher.kt
+++ b/src/KaraLib/src/kara/internal/ResourceDispatcher.kt
@@ -11,16 +11,15 @@ import kotlin.reflect.KAnnotatedElement
 
 /** Used by the server to dispatch requests to their appropriate actions.
  */
-class ResourceDispatcher(val context: ApplicationContext, resourceTypes: List<KAnnotatedElement>) {
+class ResourceDispatcher(val context: ApplicationContext, resourceTypes: List<Pair<KAnnotatedElement, ResourceDescriptor>>) {
     private val httpMethods = Array(HttpMethod.values().size) {
         ArrayList<ResourceDescriptor>()
     }
     private val resources = HashMap<KAnnotatedElement, ResourceDescriptor>()
 
     init {
-        for (routeType in resourceTypes) {
-            val descriptor = routeType.route()
-            resources[routeType] = descriptor
+        for ((first, descriptor) in resourceTypes) {
+            resources[first] = descriptor
             httpMethods[descriptor.httpMethod.ordinal].add(descriptor)
         }
     }

--- a/src/KaraLib/src/kara/internal/RoutesBuilder.kt
+++ b/src/KaraLib/src/kara/internal/RoutesBuilder.kt
@@ -7,19 +7,51 @@ import kotlinx.reflection.findClasses
 import kotlinx.reflection.kotlinCached
 import java.util.*
 import kotlin.reflect.KAnnotatedElement
+import kotlin.reflect.KClass
 import kotlin.reflect.full.declaredMemberFunctions
+import kotlin.reflect.full.superclasses
 
 val karaAnnotations = listOf(Get::class, Post::class, Put::class, Delete::class, Route::class, Location::class)
 
-private fun KAnnotatedElement.ok() = annotations.any { a -> karaAnnotations.any { a.annotationClassCached == it } }
+fun KAnnotatedElement.getKaraAnnotation() = annotations.find { karaAnnotations.contains(it.annotationClassCached) }
+
+fun KClass<*>.getKaraAnnotationFromSuper() = superclasses.find{ it.ok() }?.getKaraAnnotation()
+
+private fun KAnnotatedElement.ok() = getKaraAnnotation() != null
+
+private fun KClass<*>.inheritAnnotatedInterfaceController() : Boolean {
+    return this.superclasses.any { it.isInterfaceController() && it.ok() } && this.isFinal
+}
+
+private fun KClass<*>.isInterfaceController() : Boolean {
+    return this.annotations.map { it.annotationClassCached }.contains(InterfaceController::class)
+}
+
+private fun List<KAnnotatedElement>.toResourceDescriptorWithInerited() : List<Pair<KAnnotatedElement, ResourceDescriptor>> {
+    val descriptorList = ArrayList<Pair<KAnnotatedElement, ResourceDescriptor>>()
+    for (element in this) {
+        val karaAnnotation = element.getKaraAnnotation() ?: (element as? KClass<*>)?.getKaraAnnotationFromSuper()
+        if (karaAnnotation != null) {
+            descriptorList.add(element to element.route(karaAnnotation))
+        }
+    }
+    return descriptorList
+}
 
 @Suppress("UNCHECKED_CAST")
-fun scanPackageForResources(prefix: String, classloader: ClassLoader, cache: MutableMap<Pair<Int, String>, List<Class<*>>>) : List<KAnnotatedElement> {
+fun scanPackageForResources(prefix: String, classloader: ClassLoader, cache: MutableMap<Pair<Int, String>, List<Class<*>>>)
+        : List<Pair<KAnnotatedElement, ResourceDescriptor>> {
     try {
         val classes = classloader.findClasses(prefix, cache)
-        return classes.filterIsAssignable<Resource>().map { it.kotlinCached }.filter { it.ok() } +
-            classes.filter{ it.isAnnotationPresent(Controller::class.java) && it.kotlinCached.objectInstance != null }.
-                    flatMap { it.kotlinCached.declaredMemberFunctions.filter { it.ok() } }
+        val annotatedClasses = classes.filterIsAssignable<Resource>().map { it.kotlinCached }.filter {
+            (it.ok() && !it.isInterfaceController()) || it.inheritAnnotatedInterfaceController()
+        }.toResourceDescriptorWithInerited()
+        val annotatedFunctions = classes.filter{ it.isAnnotationPresent(Controller::class.java) && it.kotlinCached.objectInstance != null}.
+                    flatMap { it.kotlinCached.declaredMemberFunctions.filter { it.ok() } }.mapNotNull {
+            it.getKaraAnnotation()?.let {karaAnnotation -> it to it.route(karaAnnotation) }
+        }
+        return annotatedClasses + annotatedFunctions
+
     } catch(e: Throwable) {
         e.printStackTrace()
         throw RuntimeException("I'm totally failed to start up. See log :(")
@@ -27,8 +59,8 @@ fun scanPackageForResources(prefix: String, classloader: ClassLoader, cache: Mut
 }
 
 /** Test only **/
-fun scanObjects(objects : Array<Any>, classloader: ClassLoader? = null) : List<KAnnotatedElement> {
-    val answer = ArrayList<KAnnotatedElement>()
+fun scanObjects(objects : Array<Any>, classloader: ClassLoader? = null) : List<Pair<KAnnotatedElement, ResourceDescriptor>> {
+    val answer = ArrayList<Pair<KAnnotatedElement, ResourceDescriptor>>()
 
     @Suppress("UNCHECKED_CAST")
     fun scan(routesObject : Any) {
@@ -37,13 +69,14 @@ fun scanObjects(objects : Array<Any>, classloader: ClassLoader? = null) : List<K
             (innerClass as Class<Any>).kotlinCached.objectInstance?.let {
                 scan(it)
             } ?: run {
-                if (Resource::class.java.isAssignableFrom(innerClass)) {
-                    answer.add(innerClass.kotlinCached)
+                if ((innerClass.kotlinCached.ok() && !innerClass.kotlinCached.isInterfaceController()) ||
+                        (innerClass.kotlinCached.inheritAnnotatedInterfaceController())) {
+                    answer.add(innerClass.kotlinCached to innerClass.kotlinCached.route())
                 }
             }
         }
 
-        answer.addAll(newClass.kotlinCached.declaredMemberFunctions.filter { it.ok() })
+        answer.addAll(newClass.kotlinCached.declaredMemberFunctions.filter { it.ok() }.map { it to it.route() })
 
     }
 

--- a/src/KaraTests/src/kara.tests/controllers/DispatchTests.kt
+++ b/src/KaraTests/src/kara.tests/controllers/DispatchTests.kt
@@ -20,7 +20,8 @@ import kotlin.test.assertNull
 /** Tests for dispatching routes to get action info. */
 class DispatchTests() {
 
-    @Test fun runDispatchTests() {
+    @Test
+    fun runDispatchTests() {
         val appConfig = ApplicationConfig.loadFrom("src/KaraTests/src/kara.tests/test.conf")
 
         val app = object : Application(appConfig) {}
@@ -101,5 +102,55 @@ class DispatchTests() {
 
         val arrayWithNullsURL = Routes.ArrayParam(arrayOf("foo", null, "bar")).href()
         assertEquals("foo, null, bar", mockDispatch("GET", arrayWithNullsURL).stringOutput())
+    }
+
+    @Test
+    fun runInterfaceDispatchTests() {
+        val appConfig = ApplicationConfig.loadFrom("src/KaraTests/src/kara.tests/test.conf")
+
+        val app = object : Application(appConfig) {}
+
+        val dispatcher = ResourceDispatcher(app.context, scanObjects(arrayOf(Routes)))
+
+        val actionInfo = dispatcher.findDescriptor("GET", "interfacecontrollertest/Action")!!
+        assertNotNull(actionInfo)
+
+        val stringController = mockDispatch("GET", "interfacecontrollertest/Action").stringOutput()
+        assertEquals("It's implementation", stringController)
+
+        val link = Routes.InterfaceControllerTest.SomeInterfaceController::class.baseLink().href()
+        assertEquals(link, "/interfacecontrollertest/Action")
+
+    }
+
+    @Test
+    fun runInterfaceNotFinalDispatchTests() {
+        val appConfig = ApplicationConfig.loadFrom("src/KaraTests/src/kara.tests/test.conf")
+
+        val app = object : Application(appConfig) {}
+
+        val dispatcher = ResourceDispatcher(app.context, scanObjects(arrayOf(Routes)))
+
+        val actionInfo = dispatcher.findDescriptor("GET", "interfacenotfinalcontrollertest/Action")
+        assertNull(actionInfo)
+    }
+
+    @Test
+    fun runInterfaceParamDispatchTests() {
+        val appConfig = ApplicationConfig.loadFrom("src/KaraTests/src/kara.tests/test.conf")
+
+        val app = object : Application(appConfig) {}
+
+        val dispatcher = ResourceDispatcher(app.context, scanObjects(arrayOf(Routes)))
+
+        val actionInfo = dispatcher.findDescriptor("GET", "interfaceparamcontrollertest/Action")!!
+        assertNotNull(actionInfo)
+
+        val stringController = mockDispatch("GET", "interfaceparamcontrollertest/Action?code=1234").stringOutput()
+        assertEquals("It's implementation with param 1234", stringController)
+
+        val link = Routes.InterfaceParamControllerTest.SomeInterfaceController::class.baseLink().href()
+        assertEquals(link, "/interfaceparamcontrollertest/Action")
+
     }
 }

--- a/src/KaraTests/src/kara.tests/controllers/Routes.kt
+++ b/src/KaraTests/src/kara.tests/controllers/Routes.kt
@@ -181,4 +181,31 @@ object Routes {
         @Get("empty")
         fun nothing() {}
     }
+
+    object InterfaceControllerTest {
+        @InterfaceController
+        @Get("/Action")
+        open class SomeInterfaceController( handler: ActionContext.() -> ActionResult = { TextResult("It's interface") })
+            : Request(handler)
+
+        class ImplInterfaceController() : SomeInterfaceController({ TextResult("It's implementation") })
+    }
+
+    object InterfaceNotFinalControllerTest {
+        @InterfaceController
+        @Get("/Action")
+        open class SomeInterfaceController( handler: ActionContext.() -> ActionResult = { TextResult("It's interface") })
+            : Request(handler)
+
+        open class ImplInterfaceController() : SomeInterfaceController({ TextResult("It's implementation") })
+    }
+
+    object InterfaceParamControllerTest {
+        @InterfaceController
+        @Get("/Action")
+        open class SomeInterfaceController(val code: String, handler: ActionContext.() -> ActionResult = { TextResult("It's interface") })
+            : Request(handler)
+
+        class ImplInterfaceController(code: String) : SomeInterfaceController(code, { TextResult("It's implementation with param $code") })
+    }
 }

--- a/src/KaraTests/src/kara.tests/views/Html.kt
+++ b/src/KaraTests/src/kara.tests/views/Html.kt
@@ -2,6 +2,7 @@ package kara.tests.views
 
 
 import kara.link
+import kara.tests.controllers.Routes
 import org.junit.Test
 import kotlinx.html.a
 import kotlinx.html.html
@@ -22,6 +23,28 @@ class HtmlBuilderTest {
         }
 
         assertEquals("<p>This is text</p><a href=\"xxx\">Name</a>", html)
+    }
+
+    @Test fun hrefInterfaceController() {
+        val html = html {
+            a {
+                +"Name"
+                href= Routes.InterfaceControllerTest.SomeInterfaceController()
+            }
+        }
+
+        assertEquals("<a href=\"/interfacecontrollertest/Action\">Name</a>", html)
+    }
+
+    @Test fun hrefParamInterfaceController() {
+        val html = html {
+            a {
+                +"Name"
+                href= Routes.InterfaceParamControllerTest.SomeInterfaceController("1234")
+            }
+        }
+
+        assertEquals("<a href=\"/interfaceparamcontrollertest/Action?code=1234\">Name</a>", html)
     }
 }
 //fun testHtml(args : Array<String>) =


### PR DESCRIPTION
ControllerInterface annotation gives you a possibility to define
URL contracts (route interface). You define controller, but not it's
logic. Logic should be implemented in inheritor of ControllerInterface
annotated class.